### PR TITLE
bugfix: Don't warn when there are zero targets

### DIFF
--- a/functions/jump-target
+++ b/functions/jump-target
@@ -23,7 +23,7 @@
         local start
         region_highlight=()
         while buffer_idx=${BUFFER[(ib:buffer_idx+1:)$char]}
-              (( buffer_idx <= $#BUFFER ))
+              (( buffer_idx > 0 && buffer_idx <= $#BUFFER ))
         do
             target_choice=${ZSH_JUMP_TARGET_CHOICES[target_idx]}
             BUFFER[buffer_idx]=$target_choice


### PR DESCRIPTION
To reproduce:

``` zsh
$ zsh -f
% fpath+=(/home/daniel/me/zsh-jump-target/functions/)
% bindkey -e
% autoload -Uz jump-target
% zle -N jump-target
% bindkey '^T' jump-target
% :
% <Ctrl+t><Ctrl+t>
(anon):27: BUFFER: assignment to invalid subscript range
% 
% 
```

That's because both `$buffer_idx` and `$#BUFFER` were zero, so [line 29](https://github.com/scfrazer/zsh-jump-target/blob/a7f6ebb2f02a0bf91fff6d64ffb2dfa14c9a7a01/functions/jump-target#L29) assigned to `BUFFER[0]`.
