### PR TITLE
Enable function tracing

### DIFF
--- a/functions/jump-target
+++ b/functions/jump-target
@@ -1,5 +1,5 @@
 # Jump to a character in the command line
-() {
+jump-target() {
     typeset -g ZSH_JUMP_TARGET_CHOICES
     typeset -g ZSH_JUMP_TARGET_STYLE
 


### PR DESCRIPTION
This makes `functions -T jump-target` work, by switching to ksh-style autoloading.
